### PR TITLE
Restructuring(slash command)

### DIFF
--- a/lib/slashcommand/CommandBase.js
+++ b/lib/slashcommand/CommandBase.js
@@ -131,6 +131,14 @@ class CommandBase {
    *
    * @param description
    * @returns {CommandOptions}
+   * @example
+   * ```js
+   * .setDescriptionLocalizations({
+   *  "en-US": "Hello!",
+   *  "{locale}": "{new description}"
+   * })
+   * ```
+   * @link https://discord.com/developers/docs/reference#locales
    */
   setDescriptionLocalizations(translations) {
     if (translations == undefined) {
@@ -166,6 +174,14 @@ class CommandBase {
    *
    * @param translations
    * @returns {CommandOptions}
+   * @example
+   * ```js
+   * .setNameLocalizations({
+   *  "en-US": "Hello!",
+   *  "{locale}": "{new description}"
+   * })
+   * ```
+   * @link https://discord.com/developers/docs/reference#locales
    */
   setNameLocalizations(translations) {
     if (translations == undefined) {

--- a/lib/slashcommand/CommandBase.js
+++ b/lib/slashcommand/CommandBase.js
@@ -14,7 +14,7 @@ class CommandBase {
          */
         this.id = data.id ?? null;
       }
-      if (data.id !== undefined) {
+      if (data.type !== undefined) {
         /**
          *
          * @type {null|number}
@@ -43,12 +43,18 @@ class CommandBase {
          */
         this.name = data.name ?? '';
       }
+      if (data.name_localizations !== undefined) {
+        this.nameLocalizations = data.name_localizations;
+      }
       if (data.description !== undefined) {
         /**
          *
          * @type {string|string}
          */
         this.description = data.description ?? '';
+      }
+      if (data.description_localizations !== undefined) {
+        this.descriptionLocalizations = data.description_localizations;
       }
       if (data.options !== undefined) {
         /**
@@ -77,6 +83,7 @@ class CommandBase {
 
 
   }
+
 
   /**
    *
@@ -120,6 +127,24 @@ class CommandBase {
     this.description = description;
     return this;
   }
+  /**
+   *
+   * @param description
+   * @returns {CommandOptions}
+   */
+  setDescriptionLocalizations(translations) {
+    if (translations == undefined) {
+      throw Error('Method called setDescriptionLocalizations must have an input argument');
+    }
+    if (typeof description !== 'object') {
+      throw Error('Method called setDescriptionLocalizations is entering wrong call argument. Correct argument would be a object input.');
+    }
+    this.descriptionLocalizations = translations;
+    return this;
+  }
+
+
+
   setMaxValue(value) {
     this.maxValue = value;
     return this;
@@ -137,33 +162,26 @@ class CommandBase {
     this.name = name;
     return this;
   }
+  /**
+   *
+   * @param translations
+   * @returns {CommandOptions}
+   */
+  setNameLocalizations(translations) {
+    if (translations == undefined) {
+      throw Error('Method called setNameLocalizations must have an input argument');
+    }
+    if (typeof translations !== 'object') {
+      throw Error('Method called setNameLocalizations is entering wrong call argument. Correct argument would be a object input.');
+    }
+    this.nameLocalizations = translations;
+    return this;
+  }
+
   setType(type) {
     this.type = type;
     return this;
   }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
   /**
    *
@@ -177,6 +195,12 @@ class CommandBase {
       description: this.description,
       default_permission: this.defaultPermission
     };
+    if (this.nameLocalizations !== undefined) {
+      data.name_localizations = this.nameLocalizations;
+    }
+    if (this.descriptionLocalizations !== undefined) {
+      data.description_localizations = this.descriptionLocalizations;
+    }
     if (this.maxValue !== undefined) {
       data.max_value = this.maxValue;
     }

--- a/lib/slashcommand/CommandOptions.js
+++ b/lib/slashcommand/CommandOptions.js
@@ -15,12 +15,18 @@ class CommandOptions {
          */
         this.name = data.name ?? '';
       }
+      if (data.name_localizations !== undefined) {
+        this.nameLocalizations = data.name_localizations;
+      }
       if (data.description !== undefined) {
         /**
          *
          * @type {string|string}
          */
         this.description = data.description ?? '';
+      }
+      if (data.description_localizations !== undefined) {
+        this.descriptionLocalizations = data.description_localizations;
       }
       if (data.type !== undefined) {
         /**
@@ -69,23 +75,40 @@ class CommandOptions {
 
   }
 
-  /**
-   *
-   * @param name
-   * @returns {CommandOptions}
-   */
-  setName(name) {
-    this.name = name;
-    return this;
-  }
+
 
   /**
    *
-   * @param description
+   * @param choice
    * @returns {CommandOptions}
    */
-  setDescription(description) {
-    this.description = description;
+  addChoices(...choice) {
+    for (const choiceElement of choice) {
+      if (choiceElement instanceof Choice) {
+        this.choices.push(choiceElement);
+      }
+    }
+    return this;
+  }
+  /**
+   *
+   * @param options
+   * @returns {CommandOptions}
+   */
+  addOptions(...options) {
+    for (const optionsElement of options) {
+      if (optionsElement instanceof CommandOptions) {
+        this.options.push(optionsElement);
+      }
+    }
+    return this;
+  }
+  /***
+   *
+   * @returns {CommandOptions}
+   */
+  isRequired() {
+    this.required = true;
     return this;
   }
   /**
@@ -95,15 +118,85 @@ class CommandOptions {
   setAutocomplete() {
     if (this.autocomplete !== undefined) {
       if (!this.autocomplete) {
-        data.autocomplete = true;
+        this.autocomplete = true;
       } else {
-        Error(`AutoComplete is already enabled!`);
+        Error('AutoComplete is already enabled!');
       }
     } else {
       this.autocomplete = true;
     }
     return this;
   }
+  /**
+   *
+   * @param description
+   * @returns {CommandOptions}
+   */
+  setDescription(description) {
+    this.description = description;
+    return this;
+  }
+  setDescriptionLocalizations(translations) {
+    if (translations == undefined) {
+      throw Error('Method called setDescriptionLocalizations must have an input argument');
+    }
+    if (typeof translations !== 'object') {
+      throw Error('Method called setDescriptionLocalizations is entering wrong call argument. Correct argument would be a object input.');
+    }
+    this.descriptionLocalizations = translations;
+    return this;
+  }
+
+
+
+
+
+
+  /**
+   *
+   * @param name
+   * @returns {CommandOptions}
+   */
+  setName(name) {
+    this.name = name;
+    return this;
+  }
+  setNameLocalizations(translations) {
+    if (translations == undefined) {
+      throw Error('Method called setNameLocalizations must have an input argument');
+    }
+    if (typeof translations !== 'object') {
+      throw Error('Method called setNameLocalizations is entering wrong call argument. Correct argument would be a object input.');
+    }
+    this.nameLocalizations = translations;
+    return this;
+  }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   /**
    *
@@ -128,42 +221,14 @@ class CommandOptions {
     return this;
   }
 
-  /***
-   *
-   * @returns {CommandOptions}
-   */
-  isRequired() {
-    this.required = true;
-    return this;
-  }
 
-  /**
-   *
-   * @param choice
-   * @returns {CommandOptions}
-   */
-  addChoices(...choice) {
-    for (const choiceElement of choice) {
-      if (choiceElement instanceof Choice) {
-        this.choices.push(choiceElement);
-      }
-    }
-    return this;
-  }
 
-  /**
-   *
-   * @param options
-   * @returns {CommandOptions}
-   */
-  addOptions(...options) {
-    for (const optionsElement of options) {
-      if (optionsElement instanceof CommandOptions) {
-        this.options.push(optionsElement);
-      }
-    }
-    return this;
-  }
+
+
+
+
+
+
 
   /**
    * @returns {{name, options: (CommandOptions), description, type, choices: (Choice[]), required: (*|boolean), autocomplete: boolean}}
@@ -173,8 +238,14 @@ class CommandOptions {
       type: this.type,
       name: this.name,
       description: this.description ?? 'no-description',
-      required: this.required ?? false,
+      required: this.required ?? false
     };
+    if (this.nameLocalizations !== undefined) {
+      data.name_localizations = this.nameLocalizations;
+    }
+    if (this.descriptionLocalizations !== undefined) {
+      data.description_localizations = this.descriptionLocalizations;
+    }
     if (this.autocomplete !== undefined) {
       data.autocomplete = this.autocomplete;
     }

--- a/lib/slashcommand/CommandOptions.js
+++ b/lib/slashcommand/CommandOptions.js
@@ -136,6 +136,19 @@ class CommandOptions {
     this.description = description;
     return this;
   }
+  /**
+   *
+   * @param description
+   * @returns {CommandOptions}
+   * @example
+   * ```js
+   * .setDescriptionLocalizations({
+   *  "en-US": "Hello!",
+   *  "{locale}": "{new description}"
+   * })
+   * ```
+   * @link https://discord.com/developers/docs/reference#locales
+   */
   setDescriptionLocalizations(translations) {
     if (translations == undefined) {
       throw Error('Method called setDescriptionLocalizations must have an input argument');
@@ -161,6 +174,19 @@ class CommandOptions {
     this.name = name;
     return this;
   }
+  /**
+   *
+   * @param translations
+   * @returns {CommandOptions}
+   * @example
+   * ```js
+   * .setNameLocalizations({
+   *  "en-US": "Hello!",
+   *  "{locale}": "{new description}"
+   * })
+   * ```
+   * @link https://discord.com/developers/docs/reference#locales
+   */
   setNameLocalizations(translations) {
     if (translations == undefined) {
       throw Error('Method called setNameLocalizations must have an input argument');


### PR DESCRIPTION
Discord has implemented a new way of translating the bot's command list. New methods have been implemented in `CommandBase` and both for `CommandOptions`.


How to use this method? It is necessary for you to enter an entry in the object type and placing these keys.

```js
.setDescriptionLocalizations({
     "en-US": "Hello!",
     "{locale}": "{new description}"
   })
.setNameLocalizations({
     "en-US": "Hello!",
     "{locale}": "{new name}"
    })
```

If you're not sure how to use Discord's list of locales, you can [click here](https://discord.com/developers/docs/reference#locales) to learn more about the list that Discord is recommending to add to this key.


The new keys implemented in the class are: `nameLocalizations`, `descriptionLocalizations`.




